### PR TITLE
fix: source config relative to script instead of script's current directory

### DIFF
--- a/vpn/add-vpn-iptables-rules.sh
+++ b/vpn/add-vpn-iptables-rules.sh
@@ -354,7 +354,7 @@ delete_dns_routes() {
 
 # If configuration variables are not present, source the config file from the PWD.
 if [ -z "${MARK}" ]; then
-	source ./vpn.conf
+	source `dirname "$0"`/vpn.conf
 fi
 
 # Default to tun0 if no device name was passed to this script

--- a/vpn/updown.sh
+++ b/vpn/updown.sh
@@ -206,8 +206,9 @@ delete_all_routes() {
 # If configuration variables are not present, source config file from the PWD.
 CONFIG_FILE=""
 if [ -z "${MARK}" ]; then
-	CONFIG_FILE="${PWD}/vpn.conf"
-	source ./vpn.conf
+	CONFIG_DIR=`dirname "$0"`
+	CONFIG_FILE="${CONFIG_DIR}/vpn.conf"
+	source ${CONFIG_DIR}/vpn.conf
 fi
 
 # If no provider was given, assume openvpn for backwards compatibility.


### PR DESCRIPTION
When launching the script from a directory other than the current, the source command to load config variables fails since its looking in PWD instead of the relative to the script. 