### PR TITLE
Bugfix when specifying CONFIG_FILE var

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,9 @@ This script is designed to be run on the UDM-Pro, UDM, UDM-SE, UDR, or UXG-Pro. 
     [Interface]
     PrivateKey = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     Address = 10.68.1.88/32,fc00:dddd:eeee:bb01::5:6666/128
-    PostUp = sh /etc/split-vpn/vpn/updown.sh %i up
-    PreDown = sh /etc/split-vpn/vpn/updown.sh %i down
+    PreUp = CONFIG_FILE=/etc/split-vpn/vpn/vpn.conf sh /etc/split-vpn/vpn/updown.sh %i pre-up
+    PostUp = CONFIG_FILE=/etc/split-vpn/vpn/vpn.conf sh /etc/split-vpn/vpn/updown.sh %i up
+    PreDown = CONFIG_FILE=/etc/split-vpn/vpn/vpn.conf sh /etc/split-vpn/vpn/updown.sh %i down
     Table = 101
 
     [Peer]

--- a/vpn/add-vpn-iptables-rules.sh
+++ b/vpn/add-vpn-iptables-rules.sh
@@ -402,8 +402,9 @@ delete_dns_routes() {
 }
 
 # If configuration variables are not present, source the config file from the PWD.
+CONFIG_FILE="${CONFIG_FILE:-$PWD/vpn.conf}"
 if [ -z "${MARK}" ]; then
-	. ./vpn.conf
+	. "$CONFIG_FILE"
 fi
 
 # Default to tun0 if no device name was passed to this script

--- a/vpn/updown.sh
+++ b/vpn/updown.sh
@@ -272,10 +272,9 @@ delete_all_routes() {
 ### END OF FUNCTIONS ###
 
 # If configuration variables are not present, source config file from the PWD.
-CONFIG_FILE=""
+CONFIG_FILE="${CONFIG_FILE:-$PWD/vpn.conf}"
 if [ -z "${MARK}" ]; then
-	CONFIG_FILE="${PWD}/vpn.conf"
-	. ./vpn.conf
+	. "$CONFIG_FILE"
 fi
 
 # If no provider was given, assume openvpn for backwards compatibility.


### PR DESCRIPTION
It appears that there was a CONFIG_FILE variable, but it was unused. The scripts always try to source conf from `./vpn.conf` (so relative to the current working directory). Modify scripts so that if CONFIG_FILE is specified, it will use it, otherwise, it will fallback to using the `./vpn.conf` from the current working directly.

Additionally, the instructions for wireguard mention a PreUp script, but its not in the example, so modified it. 

This change should simplify a lot of the instructions in the README - you don't need to `cd` before executing the updown script - basically making most of these one liners, and executable from anywhere. However, I didn't update all the references in case you want to keep it as is. 