### PR TITLE
Blackholes not replaced

### DIFF
--- a/vpn/updown.sh
+++ b/vpn/updown.sh
@@ -193,8 +193,10 @@ add_blackhole_routes() {
 	if [ "${DISABLE_BLACKHOLE}" = "1" ]; then
 		delete_blackhole_routes
 	else
-		ip route replace blackhole default table ${ROUTE_TABLE}
-		ip -6 route replace blackhole default table ${ROUTE_TABLE}
+		ip route replace blackhole 0.0.0.0/1 table ${ROUTE_TABLE}
+		ip route replace blackhole 128.0.0.0/1 table ${ROUTE_TABLE}
+		ip -6 route replace blackhole ::/1 table ${ROUTE_TABLE}
+		ip -6 route replace blackhole 8000::/1 table ${ROUTE_TABLE}
 	fi
 }
 


### PR DESCRIPTION
`add_nexthop_routes()` and or `add_openvpn_routes()` will not remove the blackhole added by `add_blackhole_routes()` because the blackhole is added via `default` (0.0.0.0/0) but replaced using `0.0.0.0/1`, and `128.0.0.0/1`. 

I also noted a problem in `run_rule_watcher()` - I think.... its trying to remove the startup blackholes. But these routes are not the ones added by `add_blackhole_routes` - also, its not removing them from the `${ROUTE_TABLE}` - so this basically doesn't do anything. Additionally, there is a another method for removing blackhole routes `delete_blackhole_routes` which seems like it ought to work, for anytype of blackhole route - using 0.0.0.0/0 or 0.0.0.0/1, 128.0.0.1. 

This change fixes the problem with not removing blackholes, but please review the logic in the rule watcher - maybe I'm missing something? 