### PR TITLE
Support for splitting on destination ports

### DIFF
--- a/vpn/add-vpn-iptables-rules.sh
+++ b/vpn/add-vpn-iptables-rules.sh
@@ -161,6 +161,31 @@ add_iptables_rules() {
 		fi
 	done
 
+	# Force destination IP:PORT for IPv4 and IPv6
+	for entry in ${FORCED_DEST_IPV4_PORT}; do
+		proto=$(echo "$entry" | cut -d'-' -f1)
+		dest_ip=$(echo "$entry"   | cut -d'-' -f2)
+		dports=$(echo "$entry"    | cut -d'-' -f3)
+		if [ "$proto" = "both" ]; then
+			add_rule IPV4 mangle "PREROUTING -p tcp -d ${dest_ip} -m multiport --dports ${dports} -j MARK --set-xmark ${MARK}"
+			add_rule IPV4 mangle "PREROUTING -p udp -d ${dest_ip} -m multiport --dports ${dports} -j MARK --set-xmark ${MARK}"
+		else
+			add_rule IPV4 mangle "PREROUTING -p ${proto} -d ${dest_ip} -m multiport --dports ${dports} -j MARK --set-xmark ${MARK}"
+		fi
+	done
+
+	for entry in ${FORCED_DEST_IPV6_PORT}; do
+		proto=$(echo "$entry" | cut -d'-' -f1)
+		dest_ip=$(echo "$entry"   | cut -d'-' -f2)
+		dports=$(echo "$entry"    | cut -d'-' -f3)
+		if [ "$proto" = "both" ]; then
+			add_rule IPV6 mangle "PREROUTING -p tcp -d ${dest_ip} -m multiport --dports ${dports} -j MARK --set-xmark ${MARK}"
+			add_rule IPV6 mangle "PREROUTING -p udp -d ${dest_ip} -m multiport --dports ${dports} -j MARK --set-xmark ${MARK}"
+		else
+			add_rule IPV6 mangle "PREROUTING -p ${proto} -d ${dest_ip} -m multiport --dports ${dports} -j MARK --set-xmark ${MARK}"
+		fi
+	done
+
 	# Force source MAC:PORT
 	for entry in ${FORCED_SOURCE_MAC_PORT}; do
 		proto=$(echo "$entry" | cut -d'-' -f1)
@@ -237,6 +262,36 @@ add_iptables_rules() {
 			add_rule IPV6 mangle "PREROUTING -p udp -s ${source_ip} -m multiport --sports ${sports} -m mark --mark ${MARK} -j MARK --set-xmark 0x0"
 		else
 			add_rule IPV6 mangle "PREROUTING -p ${proto} -s ${source_ip} -m multiport --sports ${sports} -m mark --mark ${MARK} -j MARK --set-xmark 0x0"
+		fi
+	done
+
+	for entry in ${EXEMPT_DEST_IPV4_PORT}; do
+		proto=$(echo "$entry" | cut -d'-' -f1)
+		dest_ip=$(echo "$entry"   | cut -d'-' -f2)
+		dports=$(echo "$entry"    | cut -d'-' -f3)
+		if [ "$proto" = "both" ]; then
+			add_rule IPV4 mangle \
+				"PREROUTING -p tcp -d ${dest_ip} -m multiport --dports ${dports} -m mark --mark ${MARK} -j MARK --set-xmark 0x0"
+			add_rule IPV4 mangle \
+				"PREROUTING -p udp -d ${dest_ip} -m multiport --dports ${dports} -m mark --mark ${MARK} -j MARK --set-xmark 0x0"
+		else
+			add_rule IPV4 mangle \
+				"PREROUTING -p ${proto} -d ${dest_ip} -m multiport --dports ${dports} -m mark --mark ${MARK} -j MARK --set-xmark 0x0"
+		fi
+	done
+
+	for entry in ${EXEMPT_DEST_IPV6_PORT}; do
+		proto=$(echo "$entry" | cut -d'-' -f1)
+		dest_ip=$(echo "$entry"   | cut -d'-' -f2)
+		dports=$(echo "$entry"    | cut -d'-' -f3)
+		if [ "$proto" = "both" ]; then
+			add_rule IPV6 mangle \
+				"PREROUTING -p tcp -d ${dest_ip} -m multiport --dports ${dports} -m mark --mark ${MARK} -j MARK --set-xmark 0x0"
+			add_rule IPV6 mangle \
+				"PREROUTING -p udp -d ${dest_ip} -m multiport --dports ${dports} -m mark --mark ${MARK} -j MARK --set-xmark 0x0"
+		else
+			add_rule IPV6 mangle \
+				"PREROUTING -p ${proto} -d ${dest_ip} -m multiport --dports ${dports} -m mark --mark ${MARK} -j MARK --set-xmark 0x0"
 		fi
 	done
 

--- a/vpn/vpn.conf.filled.sample
+++ b/vpn/vpn.conf.filled.sample
@@ -15,6 +15,11 @@ FORCED_SOURCE_IPV4_PORT="tcp-192.168.1.1-22,32400,80:90,443,55555"
 FORCED_SOURCE_IPV6_PORT="tcp-2001:100a:d666:1a22::69-22,32400,80:90,443,55555"
 FORCED_SOURCE_MAC_PORT="both-00:ad:23:10:0a:30-22,32400,80,443,55555"
 
+# Format: [tcp/udp/both]-[IP/Destination]-[port1,port2:port3,port4,...]
+# Maximum 15 ports per entry.
+FORCED_DEST_IPV4_PORT="udp-0.0.0.0/0-3478:3489 udp-0.0.0.0/0-3490:3497 tcp-0.0.0.0/0-5223 udp-0.0.0.0/0-16384:16387,16393:16402"
+FORCED_DEST_IPV6_PORT="udp-::/0-3478:3489 udp-::/0-3490:3497 tcp-::/0-5223 udp-::/0-16384:16387,16393:16402"
+
 # Force these destinations through the VPN. 
 # These destinations will be forced regardless of source.
 # Format: [IP/nn]
@@ -39,6 +44,11 @@ EXEMPT_SOURCE_MAC="00:ad:23:10:0a:30"
 EXEMPT_SOURCE_IPV4_PORT="tcp-192.168.1.1-22,32400,80:90,443,55555"
 EXEMPT_SOURCE_IPV6_PORT="tcp-2001:100a:d666:1a22::69-22,32400,80:90,443,55555"
 EXEMPT_SOURCE_MAC_PORT="both-00:ad:23:10:0a:30-22,32400,80,443,55555"
+
+# Format: [tcp/udp/both]-[IP/MAC Source]-[port1,port2:port3,port4,...]
+# Maximum 15 ports per entry.
+EXEMPT_DEST_IPV4_PORT="tcp-0.0.0.0/0-80,443"
+EXEMPT_DEST_IPV6_PORT="tcp-::/0-80,443"
 
 # Exempt these destinations from the VPN. 
 # Format: [IP/nn]

--- a/vpn/vpn.conf.sample
+++ b/vpn/vpn.conf.sample
@@ -15,6 +15,11 @@ FORCED_SOURCE_IPV4_PORT=""
 FORCED_SOURCE_IPV6_PORT=""
 FORCED_SOURCE_MAC_PORT=""
 
+# Format: [tcp/udp/both]-[IP/Destination]-[port1,port2:port3,port4,...]
+# Maximum 15 ports per entry.
+FORCED_DEST_IPV4_PORT=""
+FORCED_DEST_IPV6_PORT=""
+
 # Force these destinations through the VPN. 
 # These destinations will be forced regardless of source.
 # Format: [IP/nn]
@@ -41,6 +46,11 @@ EXEMPT_SOURCE_MAC=""
 EXEMPT_SOURCE_IPV4_PORT=""
 EXEMPT_SOURCE_IPV6_PORT=""
 EXEMPT_SOURCE_MAC_PORT=""
+
+# Format: [tcp/udp/both]-[IP/MAC Source]-[port1,port2:port3,port4,...]
+# Maximum 15 ports per entry.
+EXEMPT_DEST_IPV4_PORT=""
+EXEMPT_DEST_IPV6_PORT=""
 
 # Exempt these destinations from the VPN. 
 # Format: [IP/nn]


### PR DESCRIPTION
Hi, thank you for your work. I was missing the option to split the VPN based on destination ports, so this is what i added. The use case is simple, i live in Qatar and things like Facetime are blocked because they do not have a license to operate telecommunication services in the country 🙄. So i added support for the following in the `vpn.conf` and `add-vpn-iptables-rules.sh`:

```
FORCED_DEST_IPV4_PORT="udp-0.0.0.0/0-3478:3489 udp-0.0.0.0/0-3490:3497 tcp-0.0.0.0/0-5223 udp-0.0.0.0/0-16384:16387,16393:16402"
FORCED_DEST_IPV6_PORT="udp-::/0-3478:3489 udp-::/0-3490:3497 tcp-::/0-5223 udp-::/0-16384:16387,16393:16402"
```

And also matching exemptions for completeness, even though i dont use them:
```
EXEMPT_DEST_IPV4_PORT=""
EXEMPT_DEST_IPV6_PORT=""
```

It's now possible to send specific services like Facetime over VPN while letting everything else go out over the local WAN to avoid latency or other slowdowns caused by VPNs.